### PR TITLE
Add build and publish workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -25,9 +25,7 @@ jobs:
     - run: npm run build
     - run: cat /home/runner/work/_temp/.npmrc
     - name: Publish to GitHub Packages
-      if: github.event_name == 'release'
-      run: |
-        npm version from-git --no-git-tag-version
-        npm publish --verbos
+      run: 
+        npm publish --verbose
       env:
         NODE_AUTH_TOKEN: ${{github.token}}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -7,7 +7,7 @@ on:
     branches:
     - main
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build-and-publish:
@@ -24,6 +24,10 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: cat /home/runner/work/_temp/.npmrc
-    - run: npm publish --verbose --access public
+    - name: Publish to GitHub Packages
+      if: github.event_name == 'release'
+      run: |
+        npm version from-git --no-git-tag-version
+        npm publish --verbos
       env:
         NODE_AUTH_TOKEN: ${{github.token}}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -37,7 +37,6 @@ jobs:
     - name: Upload build artifact
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
-        name: package
         path: out/*.tgz
     - name: Attach build artifact to release
       if: github.event_name == 'release'

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,3 +24,5 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{github.token}}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -43,5 +43,5 @@ jobs:
       if: github.event_name == 'release'
       uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # 2.0.8
       with:
-        files: out/*.tgz
+        files: out/
     

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,6 +26,6 @@ jobs:
     - run: cat /home/runner/work/_temp/.npmrc
     - name: Publish to GitHub Packages
       run: 
-        npm publish --verbose
+        npm publish --verbose --access public
       env:
         NODE_AUTH_TOKEN: ${{github.token}}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         node-version: '20.x'
         registry-url: 'https://npm.pkg.github.com'
+      env:
+        NODE_AUTH_TOKEN: ${{github.token}}
     - run: npm ci
     - run: npm run build
     - run: npm publish --access public

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,23 @@
+name: Build and Publish
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  release:
+    types: [created]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+      with:
+        node-version: '20.x'
+        registry-url: 'https://npm.pkg.github.com'
+    - run: npm ci
+    - run: npm run build
+    - run: npm publish

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -17,7 +17,7 @@ jobs:
       packages: write
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-    - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+    - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
       with:
         node-version: '20.x'
         registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -7,25 +7,41 @@ on:
     branches:
     - main
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      # write is required to write to releases
+      contents: write
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
       with:
         node-version: '20.x'
-        registry-url: 'https://npm.pkg.github.com'
-    - run: npm ci
-    - run: npm run build
-    - run: cat /home/runner/work/_temp/.npmrc
-    - name: Publish to GitHub Packages
-      run: 
-        npm publish --verbose --access public
-      env:
-        NODE_AUTH_TOKEN: ${{github.token}}
+    - name: Install Dependencies
+      run: npm ci
+    - name: Build
+      run: npm run build
+    - name: Create Package
+      run: |
+        if npm version --no-git-tag-version from-git > /dev/null 2>&1; then
+          echo "Using auto version based on git tag"
+        else
+          echo "Using version 0.0.0-dev"
+          npm version --no-git-tag-version 0.0.0-dev
+        fi
+        mkdir out
+        npm pack --pack-destination out
+    - name: Upload build artifact
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      with:
+        name: package
+        path: out/*.tgz
+    - name: Attach build artifact to release
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # 2.0.8
+      with:
+        files: out/*.tgz
+    

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,6 +26,6 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: cat /home/runner/work/_temp/.npmrc
-    - run: npm publish --access public
+    - run: npm publish --dry-run --verbose --access public
       env:
         NODE_AUTH_TOKEN: ${{github.token}}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -37,7 +37,8 @@ jobs:
     - name: Upload build artifact
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
-        path: out/*.tgz
+        name: package
+        path: out/
     - name: Attach build artifact to release
       if: github.event_name == 'release'
       uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # 2.0.8

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,6 +24,7 @@ jobs:
         scope: "@${{github.repository_owner}}"
     - run: npm ci
     - run: npm run build
+    - run: cat ~/.npmrc
     - run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{github.token}}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -25,6 +25,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{github.token}}
     - run: npm ci
     - run: npm run build
+    - run: cat /home/runner/work/_temp/.npmrc
     - run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{github.token}}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,10 +21,8 @@ jobs:
       with:
         node-version: '20.x'
         registry-url: 'https://npm.pkg.github.com'
-        scope: "@${{github.repository_owner}}"
     - run: npm ci
     - run: npm run build
-    - run: cat ~/.npmrc
-    - run: npm publish
+    - run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{github.token}}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         node-version: '20.x'
         registry-url: 'https://npm.pkg.github.com'
+        scope: "@${{github.repository_owner}}"
     - run: npm ci
     - run: npm run build
     - run: npm publish

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,11 +21,9 @@ jobs:
       with:
         node-version: '20.x'
         registry-url: 'https://npm.pkg.github.com'
-      env:
-        NODE_AUTH_TOKEN: ${{github.token}}
     - run: npm ci
     - run: npm run build
     - run: cat /home/runner/work/_temp/.npmrc
-    - run: npm publish --dry-run --verbose --access public
+    - run: npm publish --verbose --access public
       env:
         NODE_AUTH_TOKEN: ${{github.token}}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { render } from '@react-email/components';
 import { Command } from 'commander';
 import fs from 'fs';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "watcloud-emails",
-  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "watcloud-emails",
-      "version": "0.0.1",
       "dependencies": {
         "@react-email/components": "0.0.25",
         "commander": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@watonomous/watcloud-emails",
+  "version": "0.0.2",
   "bin": {
     "watcloud-emails": "dist/cli/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "watcloud-emails",
+  "name": "@watonomous/watcloud-emails",
   "version": "0.0.1",
   "bin": {
     "watcloud-emails": "dist/cli/index.js"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "dev": "concurrently --kill-others \"email dev\" \"tsc -w\"",
     "build": "tsc",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "postinstall": "npm run build"
   },
   "dependencies": {
     "@react-email/components": "0.0.25",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "dev": "concurrently --kill-others \"email dev\" \"tsc -w\"",
     "build": "tsc",
-    "prepack": "npm run build",
-    "postinstall": "npm run build"
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@react-email/components": "0.0.25",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "watcloud-emails",
   "version": "0.0.1",
-  "bin": "./dist/cli/index.js",
+  "bin": {
+    "watcloud-emails": "dist/cli/index.js"
+  },
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@watonomous/watcloud-emails",
-  "version": "0.0.2",
   "bin": {
     "watcloud-emails": "dist/cli/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "watcloud-emails",
   "version": "0.0.1",
   "bin": "./dist/cli/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "dev": "concurrently --kill-others \"email dev\" \"tsc -w\"",
     "build": "tsc",
-    "dev": "concurrently --kill-others \"email dev\" \"tsc -w\""
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@react-email/components": "0.0.25",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@watonomous/watcloud-emails",
-  "version": "0.0.1",
   "bin": {
     "watcloud-emails": "dist/cli/index.js"
   },


### PR DESCRIPTION
This PR adds a workflow to build and publish the package. The package is published as a tgz file in build artifacts and releases.

Installation workflow from build artifact:
1. Download the build artifact, extract to see the .tgz file
2. `npm i -g <path_to_file.tgz>`
3. `watcloud-emails -h`

Installation workflow from releases:
1. Download the tgz file from a release
2. `npm i -g <path_to_file.tgz>`
3. `watcloud-emails -h`