### PR TITLE
Fix missing release artifacts

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -43,5 +43,5 @@ jobs:
       if: github.event_name == 'release'
       uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # 2.0.8
       with:
-        files: out/
+        files: out/*.tgz
     


### PR DESCRIPTION
This PR fixes:

```
🤔 Pattern 'out/' does not match any files.
```

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/5a87fecc-1656-48c0-91e3-190e927ac1c1">

https://github.com/WATonomous/watcloud-emails/actions/runs/11308978127/job/31452354171