### PR TITLE
Serve static assets using dev server during development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,5 @@ dist
 # End of https://www.toptal.com/developers/gitignore/api/node
 
 /.react-email
+# For storing development cache
+/emails/static/cache

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "concurrently --kill-others \"email dev\" \"tsc -w\"",
+    "dev": "NODE_ENV=development concurrently --kill-others \"email dev\" \"tsc -w\"",
     "build": "tsc",
     "prepack": "npm run build"
   },


### PR DESCRIPTION
A bug was introduced in #7 where WATcloudURI-based images can't be loaded in the development environment. This PR fixes this.

Before:
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/f0833cc8-cfe2-485d-b697-3e2226578de2">


After:

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/a3082519-e9c3-4a75-91d1-0fbb9b78bea7">
