### PR TITLE
Simplify styles and remove unused imports

### DIFF
--- a/emails/blog-update.tsx
+++ b/emails/blog-update.tsx
@@ -1,20 +1,13 @@
 import {
-    Body,
-    Container,
-    Head,
     Heading,
     Hr,
-    Html,
     Img,
     Link,
-    Preview,
-    Section,
     Text
 } from "@react-email/components";
-import dedent from "dedent-js";
 import { z } from "zod";
-import { WATcloudEmail } from "./_common/watcloud-email";
 import { getAsset, registerAsset, WATcloudURI } from "../utils/watcloud-uri";
+import { WATcloudEmail } from "./_common/watcloud-email";
 
 const WATcloudBlogUpdateEmailProps = z.object({
     path: z.string(),

--- a/emails/onboarding.tsx
+++ b/emails/onboarding.tsx
@@ -1,11 +1,6 @@
 import {
-    Body,
-    Container,
-    Head,
-    Html,
-    Img,
+    Hr,
     Link,
-    Preview,
     Section,
     Text
 } from "@react-email/components";
@@ -25,7 +20,7 @@ export const WATcloudOnboardingEmail = (props: WATcloudOnboardingEmailProps) => 
 
     const previewText = `Welcome to WATcloud! Your access has been updated.`;
     const accessInstructions = (
-        <ul style={{ color: "#000", fontSize: "14px", lineHeight: "24px" }}>
+        <ul style={{ fontSize: "14px", lineHeight: "24px" }}>
             {services?.map((service) => (
                 <li key={service}>{service}</li>
             ))}
@@ -34,28 +29,26 @@ export const WATcloudOnboardingEmail = (props: WATcloudOnboardingEmailProps) => 
 
     return (
         <WATcloudEmail previewText={previewText}>
-            <Text style={{ color: "#000", fontSize: "14px", lineHeight: "24px" }}>
-                Hi {name},
-            </Text>
-            <Text style={{ color: "#000", fontSize: "14px", lineHeight: "24px", marginTop: "10px" }}>
+            <Text>Hi {name},</Text>
+            <Text>
                 Welcome to WATcloud, WATonomous's compute cluster and infrastructure. We are excited to have you on board!
             </Text>
-            <Text style={{ color: "#000", fontSize: "14px", lineHeight: "24px", marginTop: "10px" }}>
+            <Text>
                 This email confirms that your access to WATcloud has been successfully updated.
             </Text>
-            <Section style={{ marginTop: "20px", marginBottom: "20px" }}>
-                <Text style={{ color: "#000", fontSize: "14px", lineHeight: "24px" }}>
-                    Here's a list of services that you have access to:
-                </Text>
+            <Hr />
+            <Section>
+                <Text>Here's a list of services that you have access to:</Text>
                 {accessInstructions}
-                <Text style={{ color: "#000", fontSize: "14px", lineHeight: "24px", marginTop: "10px" }}>
+                <Text>
                     Access instructions for each service can be found in the <Link href="https://cloud.watonomous.ca/docs/services" style={{ color: "#1e90ff", textDecoration: "none" }}>Services</Link> documentation.
                 </Text>
             </Section>
-            <Text style={{ color: "#000", fontSize: "14px", lineHeight: "24px", marginTop: "10px" }}>
+            <Hr />
+            <Text>
                 If you have any questions, please reach out to your <Link href="https://cloud.watonomous.ca/docs/services#watcloud-contact" style={{ color: "#1e90ff", textDecoration: "none" }}>WATcloud contact</Link> or the WATcloud team at <Link href={`mailto:infra-outreach@watonomous.ca`} style={{ color: "#1e90ff", textDecoration: "none" }}>infra-outreach@watonomous.ca</Link>.
             </Text>
-            <Text style={{ color: "#000", fontSize: "14px", lineHeight: "24px", marginTop: "20px" }}>
+            <Text>
                 Vroom vroom,
             </Text>
             <pre style={{ fontFamily: "Courier New, monospace" }}>


### PR DESCRIPTION
This PR removes unneeded styles and simplifies imports. The only visual changes are minor font color, spacing, and dividers.

Before:

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/9f6138ac-347a-4cdd-bfee-7c21dd779863">

After:

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/5e5b0439-c179-41fd-91d2-778d0cf78922">
