### PR TITLE
Use `/dev/stdin` instead of `0` when using with readFileSync

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -34,7 +34,7 @@ program
         if (options.data) {
             if (options.data === '-') {
                 // Read from stdin
-                data = JSON.parse(fs.readFileSync(0, 'utf-8'));
+                data = JSON.parse(fs.readFileSync('/dev/stdin', 'utf-8'));
             } else {
                 data = JSON.parse(options.data);
             }
@@ -64,7 +64,7 @@ program
         if (options.data) {
             if (options.data === '-') {
                 // Read from stdin
-                data = JSON.parse(fs.readFileSync(0, 'utf-8'));
+                data = JSON.parse(fs.readFileSync('/dev/stdin', 'utf-8'));
             } else {
                 data = JSON.parse(options.data);
             }


### PR DESCRIPTION
Sometimes, especially when reading large inputs from stdin, we get the following error:

```
node:internal/fs/sync:25
  return binding.readFileUtf8(path, stringToFlags(flag));
                 ^

Error: EAGAIN: resource temporarily unavailable, read
    at Object.readFileUtf8 (node:internal/fs/sync:25:18)
    at Object.readFileSync (node:fs:441:19)
    at /usr/local/lib/node_modules/@watonomous/watcloud-emails/dist/cli/index.js:74:44
    at Generator.next (<anonymous>)
    at /usr/local/lib/node_modules/@watonomous/watcloud-emails/dist/cli/index.js:9:71
    at new Promise (<anonymous>)
    at __awaiter (/usr/local/lib/node_modules/@watonomous/watcloud-emails/dist/cli/index.js:5:12)
    at Command.<anonymous> (/usr/local/lib/node_modules/@watonomous/watcloud-emails/dist/cli/index.js:69:41)
    at Command.listener [as _actionHandler] (/usr/local/lib/node_modules/@watonomous/watcloud-emails/node_modules/commander/lib/command.js:542:17)
    at /usr/local/lib/node_modules/@watonomous/watcloud-emails/node_modules/commander/lib/command.js:1502:14 {
  errno: -11,
  code: 'EAGAIN',
  syscall: 'read'
}
```

This appears to be because `process.stdin.fd` only operates on nonblocking mode. This PR accesses `/dev/stdin` directly instead of using `0`.

References:
- https://stackoverflow.com/a/75948127/4527337