### PR TITLE
Add the list of active terms to onboarding email

### DIFF
--- a/emails/onboarding.tsx
+++ b/emails/onboarding.tsx
@@ -11,6 +11,7 @@ import { WATcloudEmail } from "./_common/watcloud-email";
 const WATcloudOnboardingEmailProps = z.object({
     name: z.string(),
     services: z.array(z.string()),
+    activeTerms: z.array(z.string()),
 });
 
 type WATcloudOnboardingEmailProps = z.infer<typeof WATcloudOnboardingEmailProps>;
@@ -35,8 +36,16 @@ export const WATcloudOnboardingEmail = (props: WATcloudOnboardingEmailProps) => 
                 You are receiving this email because you have been granted access to WATcloud, or your access has been updated.
             </Text>
             <Hr />
+            <Text>
+                Your access is valid for the following terms:
+            </Text>
+            <ul style={{ fontSize: "14px", lineHeight: "24px" }}>
+                {props.activeTerms?.map((term) => (
+                    <li key={term}>{term}</li>
+                ))}
+            </ul>
             <Section>
-                <Text>Here's a list of services that you now have access to:</Text>
+                <Text>Here's a list of services that you have access to:</Text>
                 {accessInstructions}
                 <Text>
                     Access instructions for each service can be found in the <Link href="https://cloud.watonomous.ca/docs/services" style={{ color: "#1e90ff", textDecoration: "none" }}>Services</Link> documentation.
@@ -66,6 +75,10 @@ export const WATcloudOnboardingEmail = (props: WATcloudOnboardingEmailProps) => 
 WATcloudOnboardingEmail.PreviewProps = {
     name: "John Doe",
     services: ["Compute Cluster", "Discord", "Google Workspace"],
+    activeTerms: [
+        "2024 Fall (2024-09-01 to 2024-12-31)",
+        "2025 Winter (2025-01-01 to 2025-04-30)"
+    ],
 } as WATcloudOnboardingEmailProps;
 
 export default WATcloudOnboardingEmail;

--- a/emails/onboarding.tsx
+++ b/emails/onboarding.tsx
@@ -1,4 +1,5 @@
 import {
+    Heading,
     Hr,
     Link,
     Section,
@@ -32,31 +33,46 @@ export const WATcloudOnboardingEmail = (props: WATcloudOnboardingEmailProps) => 
         <WATcloudEmail previewText={previewText}>
             <Text>Hi {name},</Text>
             <Text>
-                Welcome to WATcloud, WATonomous's compute cluster and infrastructure.
-                You are receiving this email because you have been granted access to WATcloud, or your access has been updated.
+                Welcome to WATcloud, WATonomous's compute cluster and infrastructure!
             </Text>
-            <Hr />
             <Text>
-                Your access is valid for the following terms:
+                You are receiving this email because you have been granted access to WATcloud, or your existing access has been updated.
             </Text>
-            <ul style={{ fontSize: "14px", lineHeight: "24px" }}>
-                {props.activeTerms?.map((term) => (
-                    <li key={term}>{term}</li>
-                ))}
-            </ul>
             <Section>
-                <Text>Here's a list of services that you have access to:</Text>
+                <Heading as="h3">Your Access Details</Heading>
+                <Text>
+                    Our records indicate that you are, or have been, active during the following term(s):
+                </Text>
+                <ul style={{ fontSize: "14px", lineHeight: "24px" }}>
+                    {props.activeTerms?.map((term) => (
+                        <li key={term}>{term}</li>
+                    ))}
+                </ul>
+            </Section>
+            <Section>
+                <Heading as="h3">Services You Have Access To</Heading>
+                <Text>
+                    You now have access to the following services:
+                </Text>
                 {accessInstructions}
                 <Text>
-                    Access instructions for each service can be found in the <Link href="https://cloud.watonomous.ca/docs/services" style={{ color: "#1e90ff", textDecoration: "none" }}>Services</Link> documentation.
+                    If you are an alumnus, you may retain access to some services beyond the active terms.
                 </Text>
             </Section>
-            <Hr />
+            <Section>
+                <Heading as="h3">Getting Started</Heading>
+                <Text>
+                    Access instructions for each service are available in the <Link href="https://cloud.watonomous.ca/docs/services" style={{ color: "#1e90ff", textDecoration: "none" }}>Services Documentation</Link>.
+                </Text>
+            </Section>
+            <Section>
+                <Heading as="h3">Questions or Assistance?</Heading>
+                <Text>
+                    If you have any questions or need assistance, feel free to reach out to your <Link href="https://cloud.watonomous.ca/docs/services#watcloud-contact" style={{ color: "#1e90ff", textDecoration: "none" }}>WATcloud contact</Link> or email the WATcloud team at <Link href={`mailto:infra-outreach@watonomous.ca`} style={{ color: "#1e90ff", textDecoration: "none" }}>infra-outreach@watonomous.ca</Link>.
+                </Text>
+            </Section>
             <Text>
-                If you have any questions, please reach out to your <Link href="https://cloud.watonomous.ca/docs/services#watcloud-contact" style={{ color: "#1e90ff", textDecoration: "none" }}>WATcloud contact</Link> or the WATcloud team at <Link href={`mailto:infra-outreach@watonomous.ca`} style={{ color: "#1e90ff", textDecoration: "none" }}>infra-outreach@watonomous.ca</Link>.
-            </Text>
-            <Text>
-                Vroom vroom,
+                Vroom vroom!
             </Text>
             <pre style={{ fontFamily: "Courier New, monospace" }}>
                 {dedent(String.raw`


### PR DESCRIPTION
This PR adds an `activeTerms` input to the onboarding email. This shows a list of active terms to the user.

<img width="464" alt="image" src="https://github.com/user-attachments/assets/93c2a740-a5ea-44b8-b531-3dcf38b4260e" />
