### PR TITLE
Implement dark mode and add user-config-lookup email and mailing list email

### DIFF
--- a/emails/_common/watcloud-email.tsx
+++ b/emails/_common/watcloud-email.tsx
@@ -26,6 +26,10 @@ export function WATcloudEmail({
                 /*
                     CSS style block for dark mode
                     Dark mode requires the !important tag to override the default styles
+
+                    This has not been tested in email clients, so it may break.
+
+                    This works on Microsoft Edge but not Google Chrome, so may need to look for alternate methods?
                 */
                     @media (prefers-color-scheme: dark) {
                         body, div {
@@ -62,6 +66,22 @@ export function WATcloudEmail({
                             margin: 40px auto;
                             padding: 20px; 
                             maxWidth: 600px;
+                    }
+                    
+                    /*
+                        There probably is a way to integrate this into where the this button is actually used
+                    */
+                    .confirmation-button {
+                        background-color: #007BFF;
+                        color: #ffffff !important;
+                        padding: 10px 20px;
+                        text-decoration: none;
+                        border-radius: 5px;
+                        font-size: 18px;
+                    }
+                        
+                    .confirmation-button:hover {
+                        background-color: #0056b3;
                     }
                 `}
             </style>

--- a/emails/_common/watcloud-email.tsx
+++ b/emails/_common/watcloud-email.tsx
@@ -22,20 +22,22 @@ export function WATcloudEmail({
         <Html>
             <Head>
             <style>
-            // CSS style block for dark mode
-            // Dark mode requires the !important tag to override the default styles
                 {`
+                /*
+                    CSS style block for dark mode
+                    Dark mode requires the !important tag to override the default styles
+                */
                     @media (prefers-color-scheme: dark) {
                         body, div {
                             background-color: #333 !important;
                             color: #ffffff !important;
                         }
                         code {
-                            background-color:#c9c5c5 !important;
+                            background-color: #c9c5c5 !important;
                         }
 
                         .email-container {
-                            border: 1px solid#696969 !important;
+                            border: 1px solid #696969 !important;
                             border-radius: 5px;
                             margin: 40px auto;
                             padding: 20px; 

--- a/emails/_common/watcloud-email.tsx
+++ b/emails/_common/watcloud-email.tsx
@@ -22,6 +22,8 @@ export function WATcloudEmail({
         <Html>
             <Head>
             <style>
+            // CSS style block for dark mode
+            // Dark mode requires the !important tag to override the default styles
                 {`
                     @media (prefers-color-scheme: dark) {
                         body, div {

--- a/emails/_common/watcloud-email.tsx
+++ b/emails/_common/watcloud-email.tsx
@@ -65,7 +65,7 @@ export function WATcloudEmail({
                             border-radius: 5px;
                             margin: 40px auto;
                             padding: 20px; 
-                            maxWidth: 600px;
+                            max-width: 600px;
                     }
                     
                     /*

--- a/emails/_common/watcloud-email.tsx
+++ b/emails/_common/watcloud-email.tsx
@@ -20,10 +20,51 @@ export function WATcloudEmail({
 }) {
     return (
         <Html>
-            <Head />
+            <Head>
+            <style>
+                {`
+                    @media (prefers-color-scheme: dark) {
+                        body, div {
+                            background-color: #333 !important;
+                            color: #ffffff !important;
+                        }
+                        code {
+                            background-color:#c9c5c5 !important;
+                        }
+
+                        .email-container {
+                            border: 1px solid#696969 !important;
+                            border-radius: 5px;
+                            margin: 40px auto;
+                            padding: 20px; 
+                            maxWidth: 600px;
+                        }
+                    }
+                    
+                    body, div {
+                        background-color: #ffffff;
+                        color: #333;
+                        margin: auto;
+                        font-family: sans-serif;
+                    }
+
+                    code {
+                        background-color: #808080
+                    }
+
+                    .email-container {
+                            border: 1px solid #eaeaea;
+                            border-radius: 5px;
+                            margin: 40px auto;
+                            padding: 20px; 
+                            maxWidth: 600px;
+                    }
+                `}
+            </style>
+            </Head>
             <Preview>{previewText}</Preview>
-            <Body style={{ backgroundColor: "#ffffff", color: "#333", margin: "auto", fontFamily: "sans-serif" }}>
-                <Container style={{ border: "1px solid #eaeaea", borderRadius: "5px", margin: "40px auto", padding: "20px", maxWidth: "600px" }}>
+            <Body>
+                <Container className="email-container">
                     <Img src={getAsset('watcloud-logo').resolveFromCache()} alt="WATcloud Logo" style={{ display: "block", margin: "0 auto" }} height="100" />
                     {children}
                 </Container>

--- a/emails/mailing-list.tsx
+++ b/emails/mailing-list.tsx
@@ -32,7 +32,7 @@ export function mailingListEmail(props: mailingListEmailProps) {
         <WATcloudEmail previewText={previewText}>
             <Text>Thanks for signing up for updates from {mailingList}</Text>
             <Text>Please confirm your subscription by clicking the button below. This confirmation email will expire in {CODE_TTL_SEC / 60 / 60} hours. </Text>
-            <Link className="confirmation-button" href="{confirmationURL}">Confirm Subscription</Link>
+            <Link className="confirmation-button" href={confirmationURL}>Confirm Subscription</Link>
             <Text>If the button above does not work, please copy and paste the following URL into your browser</Text>
             <pre>{confirmationURL}</pre>
             <Text>This email was sent to {email}. If you did not request this subscription, no further action is required. You won't be subscribed if you don't click the confirmation link.</Text>

--- a/emails/mailing-list.tsx
+++ b/emails/mailing-list.tsx
@@ -1,0 +1,49 @@
+import {
+    Heading,
+    Hr,
+    Img,
+    Link,
+    Markdown,
+    Text
+} from "@react-email/components";
+import { z } from "zod";
+import { WATcloudEmail } from "./_common/watcloud-email";
+
+const CODE_TTL_SEC = 60 * 60 * 24
+
+const mailingListEmailProps = z.object({
+    email: z.string(),
+    confirmationURL: z.string(),
+    mailingList: z.string(),
+});
+
+type mailingListEmailProps = z.infer<typeof mailingListEmailProps>;
+
+export function mailingListEmail(props: mailingListEmailProps) {
+    const { 
+        email, 
+        confirmationURL,
+        mailingList,
+    } = mailingListEmailProps.parse(props);
+
+    const previewText = `Confirm your Subscription`;
+
+    return (
+        <WATcloudEmail previewText={previewText}>
+            <Text>Thanks for signing up for updates from {mailingList}</Text>
+            <Text>Please confirm your subscription by clicking the button below. This confirmation email will expire in {CODE_TTL_SEC / 60 / 60} hours. </Text>
+            <Link className="confirmation-button" href="{confirmationURL}">Confirm Subscription</Link>
+            <Text>If the button above does not work, please copy and paste the following URL into your browser</Text>
+            <pre>{confirmationURL}</pre>
+            <Text>This email was sent to {email}. If you did not request this subscription, no further action is required. You won't be subscribed if you don't click the confirmation link.</Text>
+        </WATcloudEmail>
+    );
+};
+
+mailingListEmail.PreviewProps = {
+    email: "John Doe",
+    confirmationURL: "https://google.com",
+    mailingList: "WATcloud",
+} as mailingListEmailProps;
+
+export default mailingListEmail;

--- a/emails/user-config.tsx
+++ b/emails/user-config.tsx
@@ -1,0 +1,43 @@
+import {
+    Heading,
+    Hr,
+    Img,
+    Link,
+    Markdown,
+    Text
+} from "@react-email/components";
+import { z } from "zod";
+import { getAsset, registerAsset, WATcloudURI } from "../utils/watcloud-uri";
+import { WATcloudEmail } from "./_common/watcloud-email";
+
+const userConfigEmailProps = z.object({
+    name: z.string(),
+    editLink: z.string(),
+});
+
+type userConfigEmailProps = z.infer<typeof userConfigEmailProps>;
+
+export function userConfigEmail(props: userConfigEmailProps) {
+    const { 
+        name, 
+        editLink,
+    } = userConfigEmailProps.parse(props);
+
+    const previewText = `User Configuration for ${name}`;
+
+    return (
+        <WATcloudEmail previewText={previewText}>
+            <Text>Hello {name},</Text>
+            <Text>Greetings from WATcloud! Your WATcloud user config edit link is ready for you <Link href={editLink}>here.</Link></Text>
+            <Text>If you have any questions or need assistance, don't hesitate to reach out to your WATcloud contact or the WATcloud team at <a href="mailto:infra-outreach@watonomous.ca\">infra-outreach@watonomous.ca</a>.</Text>
+            <Text>Vroom vroom, <br></br> WATcloud Team.</Text>
+        </WATcloudEmail>
+    );
+};
+
+userConfigEmail.PreviewProps = {
+    name: "John Doe",
+    editLink: "https://google.com",
+} as userConfigEmailProps;
+
+export default userConfigEmail;

--- a/emails/user-config.tsx
+++ b/emails/user-config.tsx
@@ -27,7 +27,7 @@ export function userConfigEmail(props: userConfigEmailProps) {
 
     return (
         <WATcloudEmail previewText={previewText}>
-            <Text>Hello {name},</Text>
+            <Text>Hi {name},</Text>
             <Text>Greetings from WATcloud! Your WATcloud user config edit link is ready for you <Link href={editLink}>here.</Link></Text>
             <Text>If you have any questions or need assistance, don't hesitate to reach out to your WATcloud contact or the WATcloud team at <a href="mailto:infra-outreach@watonomous.ca\">infra-outreach@watonomous.ca</a>.</Text>
             <Text>Vroom vroom, <br></br> WATcloud Team.</Text>

--- a/emails/user-config.tsx
+++ b/emails/user-config.tsx
@@ -28,7 +28,7 @@ export function userConfigEmail(props: userConfigEmailProps) {
         <WATcloudEmail previewText={previewText}>
             <Text>Hi {name},</Text>
             <Text>Greetings from WATcloud! Your WATcloud user config edit link is ready for you <Link href={editLink}>here.</Link></Text>
-            <Text>If you have any questions or need assistance, don't hesitate to reach out to your WATcloud contact or the WATcloud team at <a href="mailto:infra-outreach@watonomous.ca\">infra-outreach@watonomous.ca</a>.</Text>
+            <Text>If you have any questions or need assistance, don't hesitate to reach out to your WATcloud contact or the WATcloud team at <Link href="mailto:infra-outreach@watonomous.ca">infra-outreach@watonomous.ca</Link>.</Text>
             <Text>Vroom vroom, <br></br> WATcloud Team.</Text>
         </WATcloudEmail>
     );

--- a/emails/user-config.tsx
+++ b/emails/user-config.tsx
@@ -7,7 +7,6 @@ import {
     Text
 } from "@react-email/components";
 import { z } from "zod";
-import { getAsset, registerAsset, WATcloudURI } from "../utils/watcloud-uri";
 import { WATcloudEmail } from "./_common/watcloud-email";
 
 const userConfigEmailProps = z.object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "@watonomous/watcloud-emails",
+  "name": "watcloud-emails",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@watonomous/watcloud-emails",
+      "name": "watcloud-emails",
       "dependencies": {
         "@react-email/components": "0.0.25",
         "commander": "^12.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "watcloud-emails",
+  "name": "@watonomous/watcloud-emails",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "watcloud-emails",
+      "name": "@watonomous/watcloud-emails",
       "dependencies": {
         "@react-email/components": "0.0.25",
         "commander": "^12.1.0",
         "dedent-js": "^1.0.1",
-        "react": "18.3.1",
+        "react": "^18.3.1",
         "react-dom": "18.3.1",
         "react-email": "3.0.1",
         "zod": "^3.23.8"
@@ -18,9 +18,10 @@
         "watcloud-emails": "dist/cli/index.js"
       },
       "devDependencies": {
-        "@types/react": "18.3.4",
+        "@types/react": "^18.3.18",
         "@types/react-dom": "18.3.0",
         "concurrently": "^9.0.1",
+        "cross-env": "^7.0.3",
         "typescript": "^5.6.3"
       }
     },
@@ -1243,10 +1244,11 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.4",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
-      "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
+      "version": "18.3.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
+      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1715,6 +1717,25 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -2690,6 +2711,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "NODE_ENV=development concurrently --kill-others \"email dev\" \"tsc -w\"",
+    "dev": "cross-env NODE_ENV=development concurrently --kill-others \"email dev\" \"tsc -w\"",
     "build": "tsc",
     "prepack": "npm run build"
   },
@@ -15,15 +15,16 @@
     "@react-email/components": "0.0.25",
     "commander": "^12.1.0",
     "dedent-js": "^1.0.1",
-    "react": "18.3.1",
+    "react": "^18.3.1",
     "react-dom": "18.3.1",
     "react-email": "3.0.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/react": "18.3.4",
+    "@types/react": "^18.3.18",
     "@types/react-dom": "18.3.0",
     "concurrently": "^9.0.1",
+    "cross-env": "^7.0.3",
     "typescript": "^5.6.3"
   }
 }


### PR DESCRIPTION
Hi, I have implemented the dark mode using CSS media. This was the simplest way I could figure out how to do this. This will also require some proper colouring since right now it just inverts the light mode's colour. 

Also includes additional emails from https://github.com/WATonomous/watcloud-emails/issues/16

Resolves https://github.com/WATonomous/watcloud-emails/issues/16
Resolves https://github.com/WATonomous/watcloud-emails/issues/17